### PR TITLE
Include polyfill as peer and improve version locks

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,11 @@
     "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {
-    "react": "0.x",
-    "d3": "*"
+    "babel-polyfill": "6",
+    "react": "^0.14.7",
+    "d3": "3"
+  },
+  "peerDependencies": {
   },
   "dependencies": {
     "react-faux-dom": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-core": "^6.4.5",
     "babel-eslint": "^5.0.0-beta9",
     "babel-loader": "^6.2.2",
+    "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
@@ -45,8 +46,6 @@
     "babel-polyfill": "6",
     "react": "^0.14.7",
     "d3": "3"
-  },
-  "peerDependencies": {
   },
   "dependencies": {
     "react-faux-dom": "^2.1.1"

--- a/src/d3-react-sparkline.js
+++ b/src/d3-react-sparkline.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import d3 from 'd3'
 import React from 'react'
 import ReactFauxDOM from 'react-faux-dom'


### PR DESCRIPTION
Two `babel-polyfills` is not a good idea apparently, so it must be a peer.
